### PR TITLE
Replace xstring methods to xbytes methods for pillow > 3.0 compatibility

### DIFF
--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -569,7 +569,7 @@ draw_new(PyObject* self_, PyObject* args)
 
     self->image = image;
     if (image) {
-        PyObject* buffer = PyObject_CallMethod(image, "tostring", NULL);
+        PyObject* buffer = PyObject_CallMethod(image, "tobytes", NULL);
         if (!buffer)
             return NULL; /* FIXME: release resources */
         if (!PyString_Check(buffer)) {
@@ -1236,7 +1236,7 @@ draw_flush(DrawObject* self, PyObject* args)
     if (!buffer)
         return NULL;
 
-    result = PyObject_CallMethod(self->image, "fromstring", "N", buffer);
+    result = PyObject_CallMethod(self->image, "frombytes", "N", buffer);
     if (!result)
         return NULL;
 


### PR DESCRIPTION
Hi,

Aggdraw is broken when used with pillow > 3.0 since the `tostring` and `fromstring` methods are deprecated. 

A typical error message would be:
`Exception: tostring() has been removed. Please call tobytes() instead`

I replaced the *string methods with the equivalent `tobytes` and `frombytes`, and it seems to work again.

Best regards,
Martin
