### PR TITLE
Image tostring() replaced with tobytes()

### DIFF
--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -569,13 +569,13 @@ draw_new(PyObject* self_, PyObject* args)
 
     self->image = image;
     if (image) {
-        PyObject* buffer = PyObject_CallMethod(image, "tostring", NULL);
+        PyObject* buffer = PyObject_CallMethod(image, "tobytes", NULL);
         if (!buffer)
             return NULL; /* FIXME: release resources */
         if (!PyString_Check(buffer)) {
             PyErr_SetString(
                 PyExc_TypeError,
-                "bad 'tostring' return value (expected string)"
+                "bad 'tobytes' return value (expected string)"
                 );
             Py_DECREF(buffer);
             return NULL;


### PR DESCRIPTION
The current version of Pillow has remove support for tostring() on Image, replacing it with tobytes().

Without this change, running selftest.py results in:
```
Failed example:
    draw = Draw(im)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest selftest.testdraw[6]>", line 1, in <module>
        draw = Draw(im)
      File "/home/tnance/.virtualenvs/test_aggdraw/local/lib/python2.7/site-packages/PIL/Image.py", line 695, in tostring
        "Please call tobytes() instead.")
    Exception: tostring() has been removed. Please call tobytes() instead.
**********************************************************************
File "/home/tnance/projects/aggdraw/selftest.py", line 26, in selftest.testdraw
Failed example:
    draw.mode, draw.size
Expected:
    ('RGB', (600, 800))
Got:
    ('RGB', (800, 600))
**********************************************************************
1 items had failures:
   2 of   8 in selftest.testdraw
***Test Failed*** 2 failures.
*** 2 tests of 66 failed.
```