### PR TITLE
Pillow has replaced fromstring() with frombytes()

### DIFF
--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -1236,7 +1236,7 @@ draw_flush(DrawObject* self, PyObject* args)
     if (!buffer)
         return NULL;
 
-    result = PyObject_CallMethod(self->image, "fromstring", "N", buffer);
+    result = PyObject_CallMethod(self->image, "frombytes", "N", buffer);
     if (!result)
         return NULL;
 

--- a/selftest.py
+++ b/selftest.py
@@ -28,6 +28,15 @@ def testdraw():
 
     """
 
+def testflush():
+    """
+
+    >>> im = Image.new("RGB", (600, 800))
+    >>> draw = Draw(im)
+    >>> draw.flush().mode
+    'RGB'
+    """
+
 def testpen():
     """
 


### PR DESCRIPTION
Found another failing case, when calling `draw.flush()`.  Replaced call to `fromstring()` with call to `frombytes()` in Image.

I added a test for it in selftest.py.