### PR TITLE
Add python 3 support and other fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include aggdraw.cxx
+recursive-include agg2 *.cpp
+recursive-include agg2 *.h

--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -588,7 +588,11 @@ draw_new(PyObject* self_, PyObject* args)
         PyObject* mode_obj = PyObject_GetAttrString(image, "mode");
         if (!mode_obj)
             return NULL;
-        if (PyUnicode_Check(mode_obj)) {
+        if (PyBytes_Check(mode_obj)) {
+            strncpy(buffer, PyBytes_AS_STRING(mode_obj), sizeof buffer);
+            buffer[sizeof(buffer)-1] = '\0'; /* to be on the safe side */
+            mode = buffer;
+        } else if (PyUnicode_Check(mode_obj)) {
             PyObject* ascii_mode = PyUnicode_AsASCIIString(mode_obj);
             if (ascii_mode == NULL) {
                 mode = NULL;

--- a/aggdraw.cxx
+++ b/aggdraw.cxx
@@ -569,7 +569,7 @@ draw_new(PyObject* self_, PyObject* args)
 
     self->image = image;
     if (image) {
-        PyObject* buffer = PyObject_CallMethod(image, "tostring", NULL);
+        PyObject* buffer = PyObject_CallMethod(image, "tobytes", NULL);
         if (!buffer)
             return NULL; /* FIXME: release resources */
         if (!PyString_Check(buffer)) {
@@ -1236,7 +1236,7 @@ draw_flush(DrawObject* self, PyObject* args)
     if (!buffer)
         return NULL;
 
-    result = PyObject_CallMethod(self->image, "fromstring", "N", buffer);
+    result = PyObject_CallMethod(self->image, "frombytes", "N", buffer);
     if (!result)
         return NULL;
 

--- a/selftest.py
+++ b/selftest.py
@@ -152,6 +152,6 @@ if __name__ == "__main__":
     import doctest, selftest
     status = doctest.testmod(selftest)
     if status[0]:
-        print "*** %s tests of %d failed." % status
+        print("*** %s tests of %d failed." % status)
     else:
-        print "%s tests passed." % status[1]
+        print("%s tests passed." % status[1])

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@
 #
 from __future__ import print_function
 from distutils.core import setup, Extension
-import os, sys
+import os
+import sys
+import subprocess
 
 VERSION = "1.2.1"
 
@@ -27,11 +29,13 @@ with the WCK renderer.
 
 """
 
-# pointer to freetype build directory (tweak as necessary)
-FREETYPE_ROOT = os.environ.get('FREETYPE_ROOT', '/usr')
-
-if not os.path.isdir(FREETYPE_ROOT):
-    print("=== freetype not available (edit setup.py to enable)")
+try:
+    # pointer to freetype build directory (tweak as necessary)
+    FREETYPE_ROOT = subprocess.check_output(
+        ['freetype-config', '--prefix']).strip().decode()
+    print("=== freetype found: '{}'".format(FREETYPE_ROOT))
+except (OSError, subprocess.CalledProcessError):
+    print("=== freetype not available")
     FREETYPE_ROOT = None
 
 sources = [
@@ -69,18 +73,7 @@ if FREETYPE_ROOT:
 if sys.platform == "win32":
     libraries.extend(["kernel32", "user32", "gdi32"])
 
-try:
-    # add necessary to distutils (for backwards compatibility)
-    from distutils.dist import DistributionMetadata
-    DistributionMetadata.classifiers = None
-    DistributionMetadata.download_url = None
-    DistributionMetadata.platforms = None
-except:
-    pass
-
-
 setup(
-
     name="aggdraw",
     version=VERSION,
     author="Fredrik Lundh",
@@ -103,5 +96,4 @@ setup(
                   library_dirs=library_dirs, libraries=libraries
                   )
         ]
-
     )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with the WCK renderer.
 """
 
 # pointer to freetype build directory (tweak as necessary)
-FREETYPE_ROOT = "/usr/"
+FREETYPE_ROOT = os.environ.get('FREETYPE_ROOT', '/usr')
 
 if not os.path.isdir(FREETYPE_ROOT):
     print("=== freetype not available (edit setup.py to enable)")

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with the WCK renderer.
 """
 
 # pointer to freetype build directory (tweak as necessary)
-FREETYPE_ROOT = "../../kits/freetype-2.1.10"
+FREETYPE_ROOT = "/usr/"
 
 if not os.path.isdir(FREETYPE_ROOT):
     print "===", "freetype not available (edit setup.py to enable)"


### PR DESCRIPTION
This PR merges a few repositories together based on various google search and github search results. It takes the python 3 support from https://github.com/ejeschke/aggdraw but modifies it to make sure that `draw.mode` returns a `str` object in python 2 and python 3 instead of a `bytes` object.

Includes other fixes from @mraspaud and various compiler warning fixes.